### PR TITLE
User can access entire access token response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 0.2.0.0
+========
+
+* Drop compatiblity with hoauth2 versions <= 1.0.0.
+* Add a function for getting the oauth2 token from an authenticated request.
+* Modify encoding of oauth2 session cookies. As a consequence existing cookies will be invalid.
+
 0.1.2.1
 =======
 

--- a/src/Network/Wai/Auth/Internal.hs
+++ b/src/Network/Wai/Auth/Internal.hs
@@ -1,0 +1,26 @@
+module Network.Wai.Auth.Internal
+  ( OAuth2TokenBinary(..)
+  ) where
+
+import           Data.Binary                          (Binary(get, put))
+import qualified Network.OAuth.OAuth2                 as OA2
+
+newtype OAuth2TokenBinary =
+  OAuth2TokenBinary { unOAuth2TokenBinary :: OA2.OAuth2Token }
+  deriving (Show)
+
+instance Binary OAuth2TokenBinary where
+  put (OAuth2TokenBinary token) = do
+    put $ OA2.atoken $ OA2.accessToken token
+    put $ OA2.rtoken <$> OA2.refreshToken token
+    put $ OA2.expiresIn token
+    put $ OA2.tokenType token
+    put $ OA2.idtoken <$> OA2.idToken token
+  get = do
+    accessToken <- OA2.AccessToken <$> get
+    refreshToken <- fmap OA2.RefreshToken <$> get
+    expiresIn <- get
+    tokenType <- get
+    idToken <- fmap OA2.IdToken <$> get
+    pure $ OAuth2TokenBinary $
+      OA2.OAuth2Token accessToken refreshToken expiresIn tokenType idToken

--- a/src/Network/Wai/Middleware/Auth.hs
+++ b/src/Network/Wai/Middleware/Auth.hs
@@ -221,13 +221,13 @@ mkAuthMiddleware AuthSettings {..} = do
                           onFailure
                             status501
                             "Empty user identity is not allowed"
-                        onSuccess userIdentity = do
+                        onSuccess authLoginState = do
                           CTime now <- epochTime
                           cookie <-
                             saveAuthState $
                             AuthLoggedIn $
                             AuthUser
-                            { authUserIdentity = userIdentity
+                            { authLoginState = authLoginState
                             , authProviderName =
                                 encodeUtf8 $ getProviderName provider
                             , authLoginTime = fromIntegral now

--- a/src/Network/Wai/Middleware/Auth/OAuth2.hs
+++ b/src/Network/Wai/Middleware/Auth/OAuth2.hs
@@ -156,6 +156,8 @@ $(deriveJSON defaultOptions { fieldLabelModifier = toLowerUnderscore . drop 3} '
 --
 -- If called on a @Request@ behind the middleware, should always return a
 -- @Just@ value.
+--
+-- @since 0.2.0.0
 getAccessToken :: Request -> Maybe OA2.OAuth2Token
 getAccessToken req = do
   user <- MA.getAuthUser req

--- a/src/Network/Wai/Middleware/Auth/OAuth2.hs
+++ b/src/Network/Wai/Middleware/Auth/OAuth2.hs
@@ -181,4 +181,4 @@ $(deriveJSON defaultOptions { fieldLabelModifier = toLowerUnderscore . drop 3} '
 getAccessToken :: Request -> Maybe OA2.OAuth2Token
 getAccessToken req = do
   user <- MA.getAuthUser req
-  unOAuth2TokenBinary <$> decode (SL.fromStrict (authUserIdentity user))
+  unOAuth2TokenBinary <$> decode (SL.fromStrict (authLoginState user))

--- a/src/Network/Wai/Middleware/Auth/Provider.hs
+++ b/src/Network/Wai/Middleware/Auth/Provider.hs
@@ -17,7 +17,9 @@ module Network.Wai.Middleware.Auth.Provider
   , parseProviders
   -- * User
   , AuthUser(..)
+  , AuthLoginState
   , UserIdentity
+  , authUserIdentity
   -- * Template
   , mkRouteRender
   , providersTemplate
@@ -71,7 +73,7 @@ import           Text.Hamlet                   (Render, hamlet)
 --         \@?{(ProviderUrl ["login", "complete"], [("user", "Hamlet")])}
 --         @
 --
---     * @(`UserIdentity` -> `IO` `Response`)@ - Action to call on a successfull login.
+--     * @(`AuthLoginState` -> `IO` `Response`)@ - Action to call on a successfull login.
 --     * @(`Status` -> `S.ByteString` -> `IO` `Response`)@ - Should be called in case of
 --     a failure with login process by supplying a
 --     status and a short error message.
@@ -100,7 +102,7 @@ class AuthProvider ap where
     -> Request
     -> [T.Text]
     -> Render ProviderUrl
-    -> (UserIdentity -> IO Response)
+    -> (AuthLoginState -> IO Response)
     -> (Status -> S.ByteString -> IO Response)
     -> IO Response
 
@@ -137,12 +139,19 @@ data ProviderInfo = ProviderInfo
   } deriving (Show)
 
 
--- | An arbitrary user identifer, eg. a username or an email address.
+-- | An arbitrary state that comes with logged in user, eg. a username, token or an email address.
+type AuthLoginState = S.ByteString
+
 type UserIdentity = S.ByteString
+{-# DEPRECATED UserIdentity "In favor of `AuthLoginState`" #-}
+
+authUserIdentity :: AuthUser -> UserIdentity
+authUserIdentity = authLoginState
+{-# DEPRECATED authUserIdentity "In favor of `authLoginState`" #-}
 
 -- | Representation of a user for a particular `Provider`.
 data AuthUser = AuthUser
-  { authUserIdentity :: !UserIdentity
+  { authLoginState :: !UserIdentity
   , authProviderName :: !S.ByteString
   , authLoginTime    :: !Int64
   } deriving (Generic, Show)

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-8.0
+resolver: lts-14.8
 packages:
 - '.'
 extra-deps: []

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -1,0 +1,49 @@
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+module Main (main) where
+
+import           Data.Binary                   (encode, decode)
+import qualified Data.Text                     as T
+import           Hedgehog
+import           Hedgehog.Gen                  as Gen
+import           Hedgehog.Range                as Range
+import           Network.Wai.Auth.Internal     (OAuth2TokenBinary(..))
+import qualified Network.OAuth.OAuth2.Internal as OA2
+
+main :: IO Bool
+main =
+  checkParallel $ Group "Main" [
+    ("oAuth2TokenBinaryDuality", oAuth2TokenBinaryDuality)
+  ]
+
+oAuth2TokenBinaryDuality :: Property
+oAuth2TokenBinaryDuality = property $ do
+  token <- forAll oauth2TokenBinary
+  tripping token encode (Just . decode)
+
+oauth2TokenBinary :: Gen OAuth2TokenBinary
+oauth2TokenBinary = do
+  accessToken <- OA2.AccessToken <$> anyText
+  refreshToken <- Gen.maybe $ OA2.RefreshToken <$> anyText
+  expiresIn <- Gen.maybe $ Gen.int (Range.linear 0 1000)
+  tokenType <- Gen.maybe $ anyText
+  idToken <- Gen.maybe $ OA2.IdToken <$> anyText
+  pure $ OAuth2TokenBinary $
+    OA2.OAuth2Token accessToken refreshToken expiresIn tokenType idToken
+
+anyText :: Gen T.Text
+anyText = Gen.text (Range.linear 0 100) Gen.unicodeAll
+
+-- The `OAuth2Token` type from the `hoauth2` library does not have a `Eq`
+-- instance, and it's constituent parts don't have a `Generic` instance. Hence
+-- this orphan instance here.
+instance Eq OAuth2TokenBinary where
+  (OAuth2TokenBinary t1) == (OAuth2TokenBinary t2) =
+    all id
+      [ OA2.atoken (OA2.accessToken t1) == OA2.atoken (OA2.accessToken t2)
+      , (OA2.rtoken <$> OA2.refreshToken t1) == (OA2.rtoken <$> OA2.refreshToken t2)
+      , OA2.expiresIn t1 == OA2.expiresIn t2
+      , OA2.tokenType t1 == OA2.tokenType t2
+      , (OA2.idtoken <$> OA2.idToken t1) == (OA2.idtoken <$> OA2.idToken t2)
+      ]

--- a/wai-middleware-auth.cabal
+++ b/wai-middleware-auth.cabal
@@ -1,6 +1,6 @@
 cabal-version:       1.18
 name:                wai-middleware-auth
-version:             0.1.2.2
+version:             0.2.0.0
 synopsis:            Authentication middleware that secures WAI application
 description:         Please see the README and Haddocks at <https://www.stackage.org/package/wai-middleware-auth>
 license:             MIT
@@ -35,7 +35,7 @@ library
                      , clientsession
                      , cookie
                      , exceptions
-                     , hoauth2              >= 0.5.0
+                     , hoauth2              >= 1.0
                      , http-client
                      , http-client-tls
                      , http-conduit

--- a/wai-middleware-auth.cabal
+++ b/wai-middleware-auth.cabal
@@ -18,6 +18,7 @@ library
                        Network.Wai.Middleware.Auth.OAuth2.Google
                        Network.Wai.Middleware.Auth.Provider
                        Network.Wai.Auth.Executable
+                       Network.Wai.Auth.Internal
   other-modules:       Paths_wai_middleware_auth
                        Network.Wai.Auth.AppRoot
                        Network.Wai.Auth.Config
@@ -68,6 +69,19 @@ executable wai-auth
                      , optparse-simple
                      , wai-middleware-auth
                      , warp
+  ghc-options:         -Wall -threaded -rtsopts -with-rtsopts=-N
+
+test-suite spec
+  default-language:    Haskell2010
+  type:                exitcode-stdio-1.0
+  main-is:             Main.hs
+  hs-source-dirs:      test
+  build-depends:       base
+                     , binary
+                     , hedgehog
+                     , hoauth2
+                     , text
+                     , wai-middleware-auth
   ghc-options:         -Wall -threaded -rtsopts -with-rtsopts=-N
 
 source-repository head


### PR DESCRIPTION
Hi there! Thank you for creating and maintaining this project, it's great!

I'm looking to put OAuth2 login in front of a WAI project. `wai-middleware-auth` is perfect for my use case, apart from one thing: Of the data returned by the OAuth2 provider in response to a token request and the end of the login flow only the access token is made available to the application. The response, described by the [`OAuth2Token`] type in `hoauth2` contains a number of other fields I'm interested in. I could retrieve them using the access token, but that would require an additional HTTP request to the OAuth2 provider request which seems wasteful.

I made some changes on a fork to support the personal project, giving access to the whole token response. Is there an interest in merging a change like that back?

If so I'm happy to clean up this PR a bit further in advance of a review. I wouldn't advice to merge these changes just yet, because:
- I need to test them a bit more thoroughly.
- They break the behavior of the existing `getAuthUser` function without breaking any types, so anyone upgrading to this version would be in for a nasty surprise at runtime.

I'm happy to fix these issues (and others that may come up in review), just wanted to briefly check if there's an interest for this change in the first place before putting in the effort.

Thank you for reading, and for your work on this library!

[`OAuth2Token`]: https://www.stackage.org/haddock/lts-14.8/hoauth2-1.8.9/Network-OAuth-OAuth2-Internal.html#t:OAuth2Token