### PR TITLE
Set SameSite=Lax attribute on cookies

### DIFF
--- a/src/Network/Wai/Auth/ClientSession.hs
+++ b/src/Network/Wai/Auth/ClientSession.hs
@@ -26,9 +26,10 @@ import           System.PosixCompat.Time    (epochTime)
 import           Web.ClientSession          (Key, decrypt, encryptIO,
                                              getDefaultKey)
 import           Web.Cookie                 (def, parseCookies, renderSetCookie,
-                                             setCookieExpires, setCookieHttpOnly,
-                                             setCookieMaxAge, setCookieName,
-                                             setCookiePath, setCookieValue)
+                                             sameSiteLax, setCookieExpires,
+                                             setCookieHttpOnly, setCookieMaxAge,
+                                             setCookieName, setCookiePath,
+                                             setCookieSameSite, setCookieValue)
 
 data Wrapper value = Wrapper
   { contained :: value
@@ -81,6 +82,7 @@ saveCookieValue key name age value = do
         , setCookiePath = Just "/"
         , setCookieHttpOnly = True
         , setCookieMaxAge = Just $ fromIntegral age
+        , setCookieSameSite = Just sameSiteLax
         })
 
 deleteCookieValue
@@ -96,4 +98,5 @@ deleteCookieValue name =
         , setCookiePath = Just "/"
         , setCookieHttpOnly = True
         , setCookieExpires = Just $ UTCTime (fromGregorian 1970 01 01) 0
+        , setCookieSameSite = Just sameSiteLax
         })

--- a/wai-middleware-auth.cabal
+++ b/wai-middleware-auth.cabal
@@ -34,7 +34,7 @@ library
                      , case-insensitive
                      , cereal
                      , clientsession
-                     , cookie
+                     , cookie               >= 0.4.2
                      , exceptions
                      , hoauth2              >= 1.0
                      , http-client


### PR DESCRIPTION
Hi there! I was curious what you'd think of the change proposed in this PR. It adds the `SameSite=Lax` attribute to session cookies, which will protect against cross-site request forgery in modern browsers. It's especially important to set this flag for session cookies such as the ones set by this library. Older browsers ignore the attribute, making it backwards-compatible. More information on browser support can be found here:

https://caniuse.com/#search=SameSite

I was put on the rack of the `SameSite` attribute by a recent announcement on the Chromium blog announcing that starting February 2020 Chrome will treat all cookies without a `SameSite` attribute specified as having the attribute `SameSite=Lax`. Other browser vendors have announced that they too plan to implement this practice. Soon then the change in this PR is going to be the default, but it's still recommended to explicitly set a `SameSite` attribute anyway if only to prevent the browser from display warnings in developer tools for cookies that do not have it set.

https://blog.chromium.org/2019/10/developers-get-ready-for-new.html

To use the `setSameSite` function in the `cookie` package we need at least version `4.2.0` of that package. That was released in April 2016, which feels like a fair while ago, but let me know if we should investigate other approaches that would give backwards compatibility further back!

I'd love to know what you think!