### PR TITLE
Google and Github pick access token from session

### DIFF
--- a/src/Network/Wai/Middleware/Auth/OAuth2.hs
+++ b/src/Network/Wai/Middleware/Auth/OAuth2.hs
@@ -125,7 +125,7 @@ instance AuthProvider OAuth2 where
                eRes <- OA2.fetchAccessToken man oauth2 $ getExchangeToken code
                case eRes of
                  Left err    -> onFailure status501 $ S8.pack $ show err
-                 Right token -> onSuccess $ encodeUtf8 $ OA2.atoken $ OA2.accessToken token
+                 Right token -> onSuccess $ encodeToken token
              _ ->
                case lookup "error" params of
                  (Just (Just "access_denied")) ->


### PR DESCRIPTION
#7 introduced a change that allowed custom OAuth2 providers to use the id token and refresh token that might be returned from the OAuth2 authorization grant flow. Unfortunately it unwittingly broke the Google and Github OAuth2 providers bundled in the library. Those providers assumed that the client session is identical to the access token, which since that PR is no longer the case.

The commit 937d9a47a0ec0d779138c70e050ecb2416f9c3c1 fixes the Github and Google providers by reverting to storing only the access token in the session, but this breaks the `getAccessToken` function that was added in #7. 

This PR is an alternative fix for the Google and Github providers. I tested it against a sample application for both. It modifies these providers to parse the new session payload and select the access token.