### PR TITLE
Add discoverURI function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+0.2.3.1
+=======
+
+* Expose `discoverURI` in `Network.Wai.Middleware.Auth.OIDC`
+
 0.2.3.0
 =======
 

--- a/src/Network/Wai/Middleware/Auth/OIDC.hs
+++ b/src/Network/Wai/Middleware/Auth/OIDC.hs
@@ -11,6 +11,7 @@ module Network.Wai.Middleware.Auth.OIDC
   ( -- * Creating a provider
     OpenIDConnect
   , discover
+  , discoverURI
   -- * Customizing a provider
   , oidcClientId
   , oidcClientSecret
@@ -165,13 +166,21 @@ instance AuthProvider OpenIDConnect where
           Just claims -> 
             pure (Just (storeClaims claims req, user))
 
--- | Fetch configuration for a provider from its discovery endpoint.
+-- | Fetch configuration for a provider from its discovery
+-- endpoint. Sets the path to @/.well-known/..@.
 --
 -- @since 0.2.3.0
 discover :: T.Text -> IO OpenIDConnect
 discover urlText = do
   base <- parseAbsoluteURI urlText
   let uri = base { U.uriPath = "/.well-known/openid-configuration" }
+  discoverURI uri
+
+-- | Fetch configuration for a provider from an exact URI.
+--
+-- @since 0.2.3.1
+discoverURI :: U.URI -> IO OpenIDConnect
+discoverURI uri = do
   metadata <- fetchMetadata uri
   jwkset <- fetchJWKSet (jwksUri metadata)
   pure OpenIDConnect 

--- a/wai-middleware-auth.cabal
+++ b/wai-middleware-auth.cabal
@@ -1,6 +1,6 @@
 cabal-version:       1.18
 name:                wai-middleware-auth
-version:             0.2.3.0
+version:             0.2.3.1
 synopsis:            Authentication middleware that secures WAI application
 description:         Please see the README and Haddocks at <https://www.stackage.org/package/wai-middleware-auth>
 license:             MIT


### PR DESCRIPTION
I'm using [Dex](https://github.com/dexidp/dex) whose root path starts at `/dex`:

```json
$ curl http://127.0.0.1:5556/dex/.well-known/openid-configuration
{
  "issuer": "http://127.0.0.1:5556/dex",
  "authorization_endpoint": "http://127.0.0.1:5556/dex/auth",
  "token_endpoint": "http://127.0.0.1:5556/dex/token",
  "jwks_uri": "http://127.0.0.1:5556/dex/keys",
  "userinfo_endpoint": "http://127.0.0.1:5556/dex/userinfo",
  "response_types_supported": [
    "code"
  ],
```

Therefore the current `discover` function is incompatible. To avoid any trivial bikeshedding on prefixes, I just expose `discoverURI` because I know the full URI that I want to discover from.