### PR TITLE
Fix oauth2 scope specification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,67 +1,58 @@
-0.2.3.1
-=======
+# 0.2.3.1
 
-* Expose `discoverURI` in `Network.Wai.Middleware.Auth.OIDC`
+- Expose `discoverURI` in `Network.Wai.Middleware.Auth.OIDC`
+- Fix bug with OAuth2 and OpenID Connect authentication where scopes were
+  separated using comma's instead of spaces.
 
-0.2.3.0
-=======
+  # 0.2.3.0
 
-* Support `hoauth2-1.11.0`
-* Drop support for `jose` versions < 0.8
-* Expose `decodeKey`
-* OAuth2 provider remove a session when an access token expires. It will use a
+- Support `hoauth2-1.11.0`
+- Drop support for `jose` versions < 0.8
+- Expose `decodeKey`
+- OAuth2 provider remove a session when an access token expires. It will use a
   refresh token if one is available to create a new session. If no refresh token
   is available it will redirect the user to re-authenticate.
-* Providers can define logic for refreshing a session without user intervention.
-* Add an OpenID Connect provider.
+- Providers can define logic for refreshing a session without user intervention.
+- Add an OpenID Connect provider.
 
-0.2.2.0
-=======
+  # 0.2.2.0
 
-* Add request logging to executable
-* Newer multistage Docker build system
+- Add request logging to executable
+- Newer multistage Docker build system
 
-0.2.1.0
-=======
+  # 0.2.1.0
 
-* Fix a bug in deserialization of `UserIdentity`
+- Fix a bug in deserialization of `UserIdentity`
 
-0.2.0.0
-=======
+  # 0.2.0.0
 
-* Drop compatiblity with hoauth2 versions <= 1.0.0.
-* Add a function for getting the oauth2 token from an authenticated request.
-* Modify encoding of oauth2 session cookies. As a consequence existing cookies will be invalid.
+- Drop compatiblity with hoauth2 versions <= 1.0.0.
+- Add a function for getting the oauth2 token from an authenticated request.
+- Modify encoding of oauth2 session cookies. As a consequence existing cookies will be invalid.
 
-0.1.2.1
-=======
+  # 0.1.2.1
 
-* Compatibility with hoauth2-1.3.0 - fixed: [#4](https://github.com/fpco/wai-middleware-auth/issues/4)
+- Compatibility with hoauth2-1.3.0 - fixed: [#4](https://github.com/fpco/wai-middleware-auth/issues/4)
 
-0.1.2.0
-=======
+  # 0.1.2.0
 
-* Implemented compatibility with hoauth2 >= 1.0.0 - fixed: [#3](https://github.com/fpco/wai-middleware-auth/issues/3)
+- Implemented compatibility with hoauth2 >= 1.0.0 - fixed: [#3](https://github.com/fpco/wai-middleware-auth/issues/3)
 
-0.1.1.2
-=======
+  # 0.1.1.2
 
-* Fixed [wai-middleware-auth-0.1.1.1 does not compile in 32 bit Linux](https://github.com/fpco/wai-middleware-auth/issues/2)
+- Fixed [wai-middleware-auth-0.1.1.1 does not compile in 32 bit Linux](https://github.com/fpco/wai-middleware-auth/issues/2)
 
-0.1.1.1
-=======
+  # 0.1.1.1
 
-* Disallow empty `userIdentity` to produce a successfull login.
-* Produces a 404 on `/favicon.ico` page if not logged in: work around for issue
+- Disallow empty `userIdentity` to produce a successfull login.
+- Produces a 404 on `/favicon.ico` page if not logged in: work around for issue
   with Chrome requesting it first and messing up the redirect url.
-* Added JQuery to the template, since it's bootstrap's requirement.
+- Added JQuery to the template, since it's bootstrap's requirement.
 
-0.1.1.0
-=======
+  # 0.1.1.0
 
-* Fixed whitelist email regex matching for Github and Google auth.
+- Fixed whitelist email regex matching for Github and Google auth.
 
-0.1.0.0
-=======
+  # 0.1.0.0
 
-* Initial implementation.
+- Initial implementation.

--- a/src/Network/Wai/Auth/Internal.hs
+++ b/src/Network/Wai/Auth/Internal.hs
@@ -76,7 +76,8 @@ oauth2Login
 oauth2Login oauth2 man oa2Scope providerName req suffix onSuccess onFailure = 
   case suffix of
     [] -> do
-      let scope = (encodeUtf8 . T.intercalate ",") <$> oa2Scope
+      -- https://tools.ietf.org/html/rfc6749#section-3.3
+      let scope = (encodeUtf8 . T.intercalate " ") <$> oa2Scope
       let redirectUrl =
             getRedirectURI $
             appendQueryParams

--- a/test/Spec/Network/Wai/Middleware/Auth/OAuth2.hs
+++ b/test/Spec/Network/Wai/Middleware/Auth/OAuth2.hs
@@ -42,7 +42,7 @@ tests = testGroup "Network.Wai.Auth.OAuth2"
         assertStatus 303 redirect3
         assertHeader
           "location"
-          (TE.encodeUtf8 host <> "/authorize?scope=scope1%2Cscope2&client_id=client-id&response_type=code&redirect_uri=http%3A%2F%2Flocalhost%2Fprefix%2Foauth2%2Fcomplete")
+          (TE.encodeUtf8 host <> "/authorize?scope=scope1%20scope2&client_id=client-id&response_type=code&redirect_uri=http%3A%2F%2Flocalhost%2Fprefix%2Foauth2%2Fcomplete")
           redirect3
 
   , testCase "when a request is made with a valid session then pass the request through" $

--- a/test/Spec/Network/Wai/Middleware/Auth/OIDC.hs
+++ b/test/Spec/Network/Wai/Middleware/Auth/OIDC.hs
@@ -43,7 +43,7 @@ tests = testGroup "Network.Wai.Auth.OIDC"
         assertStatus 303 redirect3
         assertHeader
           "location"
-          (TE.encodeUtf8 host <> "/authorize?scope=openid%2Cscope1&client_id=client-id&response_type=code&redirect_uri=http%3A%2F%2Flocalhost%2Fprefix%2Foidc%2Fcomplete")
+          (TE.encodeUtf8 host <> "/authorize?scope=openid%20scope1&client_id=client-id&response_type=code&redirect_uri=http%3A%2F%2Flocalhost%2Fprefix%2Foidc%2Fcomplete")
           redirect3
 
   , testCase "when a request is made with a valid session then pass the request through" $


### PR DESCRIPTION
They were comma separated, but according to the RFC they're space separated:

https://tools.ietf.org/html/rfc6749#section-3.3

I encountered this because Dex rejected my request when I specified more than simply `openid`, specifying e.g. `openid` and `email` yielded this error:

`time="2020-05-25T13:40:44Z" level=error msg="Failed to parse authorization request: Missing required scope(s) [\"openid\"]."`