### PR TITLE
Add getAuthUserFromVault for servant user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.2.5.0
+
+- Add `getAuthUserFromVault` for `Servant.Api.Vault` user.
+
 # 0.2.4.0
 
 - Add GitLab provider.

--- a/src/Network/Wai/Middleware/Auth.hs
+++ b/src/Network/Wai/Middleware/Auth.hs
@@ -21,6 +21,7 @@ module Network.Wai.Middleware.Auth
     , smartAppRoot
     , waiMiddlewareAuthVersion
     , getAuthUser
+    , getAuthUserFromVault
     , getDeleteSessionHeader
     , decodeKey
     ) where
@@ -315,6 +316,14 @@ userKey = unsafePerformIO Vault.newKey
 getAuthUser :: Request -> Maybe AuthUser
 getAuthUser = Vault.lookup userKey . vault
 
+-- | Get the username for the current user from the given Vault.
+--
+-- My be used instead of 'getAuthUser' in libraries that do not provide a
+-- 'Request' value, such as @Servant.Api.Vault@.
+--
+-- @since 0.2.5.0
+getAuthUserFromVault :: Vault.Vault -> Maybe AuthUser
+getAuthUserFromVault = Vault.lookup userKey
 
 -- | Current version
 --

--- a/wai-middleware-auth.cabal
+++ b/wai-middleware-auth.cabal
@@ -1,6 +1,6 @@
 cabal-version:       1.18
 name:                wai-middleware-auth
-version:             0.2.4.1
+version:             0.2.5.0
 synopsis:            Authentication middleware that secures WAI application
 description:         Please see the README and Haddocks at <https://www.stackage.org/package/wai-middleware-auth>
 license:             MIT


### PR DESCRIPTION
This change enables using the middleware in front of a Servant API.