### PR TITLE
Rename configuration option to allow list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.2.6.0
+
+- Rename email list configuration to `email_allow_list`.
+
 # 0.2.5.0
 
 - Add `getAuthUserFromVault` for `Servant.Api.Vault` user.

--- a/README.md
+++ b/README.md
@@ -39,18 +39,18 @@ providers:
     client_id: "...94cc"
     client_secret: "...166f"
     app_name: "Dev App for wai-middleware-auth"
-    email_white_list:
+    email_allow_list:
       - "^[a-zA-Z0-9._%+-]+@example.com$"
   google:
     client_id: "...qlj.apps.googleusercontent.com"
     client_secret: "...oxW"
-    email_white_list:
+    email_allow_list:
       - "^[a-zA-Z0-9._%+-]+@example.com$"
   gitlab:
     client_id: "...9cfc"
     client_secret: "...f0d0"
     app_name: "Dev App for wai-middleware-auth"
-    email_white_list:
+    email_allow_list:
       - "^[a-zA-Z0-9._%+-]+@example.com$"
 ```
 
@@ -98,7 +98,7 @@ providers:
     client_id: "...9cfc"
     client_secret: "...f0d0"
     app_name: "Dev App for wai-middleware-auth"
-    email_white_list:
+    email_allow_list:
       - "^[a-zA-Z0-9._%+-]+@mycompany.com$"
     provider_info:
       title: My Company's GitLab

--- a/src/Network/Wai/Auth/Tools.hs
+++ b/src/Network/Wai/Auth/Tools.hs
@@ -37,8 +37,8 @@ toLowerUnderscore (x:xs) = toLower x : foldr' toLowerWithUnder [] xs
       | otherwise = '_' : toLower y : acc
 
 
--- | Check email list against a whitelist and pick first one that matches or
+-- | Check email list against an allowlist and pick first one that matches or
 -- Nothing otherwise.
 getValidEmail :: [S.ByteString] -> [S.ByteString] -> Maybe S.ByteString
-getValidEmail whitelist emails =
-  listToMaybe $ filter (not . S.null) [e =~ w | e <- emails, w <- whitelist]
+getValidEmail allowlist emails =
+  listToMaybe $ filter (not . S.null) [e =~ w | e <- emails, w <- allowlist]

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -5,6 +5,7 @@ module Main (main) where
 import           Test.Tasty
 import qualified Spec.Network.Wai.Auth.Internal
 import qualified Spec.Network.Wai.Middleware.Auth.OAuth2
+import qualified Spec.Network.Wai.Middleware.Auth.OAuth2.Gitlab
 import qualified Spec.Network.Wai.Middleware.Auth.OIDC
 
 main :: IO ()
@@ -14,5 +15,6 @@ tests :: TestTree
 tests = testGroup "wai-middleware-auth"
   [ Spec.Network.Wai.Auth.Internal.tests
   , Spec.Network.Wai.Middleware.Auth.OAuth2.tests
+  , Spec.Network.Wai.Middleware.Auth.OAuth2.Gitlab.tests
   , Spec.Network.Wai.Middleware.Auth.OIDC.tests
   ]

--- a/test/Spec/Network/Wai/Middleware/Auth/OAuth2/Gitlab.hs
+++ b/test/Spec/Network/Wai/Middleware/Auth/OAuth2/Gitlab.hs
@@ -1,0 +1,33 @@
+{-# LANGUAGE OverloadedLists #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+module Spec.Network.Wai.Middleware.Auth.OAuth2.Gitlab (tests) where
+
+import           Data.Aeson ((.=))
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Types as Aeson
+import           Data.Text (Text)
+import qualified Network.Wai.Middleware.Auth.OAuth2.Gitlab as Gitlab
+import           Test.Tasty (TestTree, testGroup)
+import           Test.Tasty.HUnit (assertEqual, testCase)
+
+tests :: TestTree
+tests =
+  testGroup
+    "Network.Wai.Middleware.Auth.OAuth2.Gitlab"
+    [ testCase "when the configuration uses legacy option" $
+        assertEqual "test" (parse legacyConfig) (parse newConfig)
+    ]
+  where
+    parse v = Gitlab.gitlabEmailAllowlist <$> Aeson.parse Aeson.parseJSON v
+    config =
+      [ "app_name" .= ("test" :: Text),
+        "client_id" .= ("test" :: Text),
+        "client_secret" .= ("test" :: Text)
+      ]
+    newConfig =
+      Aeson.object
+        (config <> ["email_allow_list" .= Aeson.Array ["testMail"]])
+    legacyConfig =
+      Aeson.object
+        (config <> ["email_white_list" .= Aeson.Array ["testMail"]])

--- a/wai-middleware-auth.cabal
+++ b/wai-middleware-auth.cabal
@@ -87,6 +87,7 @@ test-suite spec
   other-modules:       Network.Wai.Auth.Test
                      , Spec.Network.Wai.Auth.Internal
                      , Spec.Network.Wai.Middleware.Auth.OAuth2
+                     , Spec.Network.Wai.Middleware.Auth.OAuth2.Gitlab
                      , Spec.Network.Wai.Middleware.Auth.OIDC
   build-depends:       base
                      , aeson


### PR DESCRIPTION
This change updates the configuration to use a more common name
for the allowed email addresses list.