### PR TITLE
Fix compilation error when compiling with GHC 9.0

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest]
         args:
-        - "--resolver nightly"
+        - "--resolver nightly --stack-yaml stack-nightly.yaml"
         - "--resolver lts-17"
         - "--resolver lts-16"
         - "--resolver lts-14 --stack-yaml stack-lts-14.yaml"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.2.5.1
+
+- Add support for GHC 9.0.
+
 # 0.2.5.0
 
 - Add `getAuthUserFromVault` for `Servant.Api.Vault` user.

--- a/src/Network/Wai/Auth/Config.hs
+++ b/src/Network/Wai/Auth/Config.hs
@@ -72,6 +72,9 @@ data AuthConfig = AuthConfig
   , configProviders  :: Object
   }
 
+$(deriveJSON defaultOptions { fieldLabelModifier = toLowerUnderscore . drop 2} ''FileServer)
+
+$(deriveJSON defaultOptions { fieldLabelModifier = toLowerUnderscore . drop 2} ''ReverseProxy)
 
 instance FromJSON AuthConfig where
   parseJSON =
@@ -100,9 +103,3 @@ instance FromJSON AuthConfig where
           (Nothing, Nothing) -> fail $ "No service is supplied. " ++ sErrMsg
       configProviders <- obj .: "providers"
       return AuthConfig {..}
-
-$(deriveJSON defaultOptions { fieldLabelModifier = toLowerUnderscore . drop 2} ''FileServer)
-
-$(deriveJSON defaultOptions { fieldLabelModifier = toLowerUnderscore . drop 2} ''ReverseProxy)
-
-

--- a/src/Network/Wai/Middleware/Auth/OAuth2.hs
+++ b/src/Network/Wai/Middleware/Auth/OAuth2.hs
@@ -66,6 +66,8 @@ getClientId = id
 getClientSecret :: T.Text -> T.Text
 getClientSecret = id
 
+$(deriveJSON defaultOptions { fieldLabelModifier = toLowerUnderscore . drop 3} ''OAuth2)
+
 -- | Aeson parser for `OAuth2` provider.
 --
 -- @since 0.1.0
@@ -135,8 +137,6 @@ tokenExpired user now tokens =
   case OA2.expiresIn tokens of
     Nothing -> False
     Just expiresIn -> authLoginTime user + (fromIntegral expiresIn) < now
-
-$(deriveJSON defaultOptions { fieldLabelModifier = toLowerUnderscore . drop 3} ''OAuth2)
 
 -- | Get the @AccessToken@ for the current user.
 --

--- a/stack-nightly.yaml
+++ b/stack-nightly.yaml
@@ -1,0 +1,3 @@
+resolver: nightly-2021-08-06
+extra-deps:
+- hoauth2-1.16.0

--- a/wai-middleware-auth.cabal
+++ b/wai-middleware-auth.cabal
@@ -1,6 +1,6 @@
 cabal-version:       1.18
 name:                wai-middleware-auth
-version:             0.2.5.0
+version:             0.2.5.1
 synopsis:            Authentication middleware that secures WAI application
 description:         Please see the README and Haddocks at <https://www.stackage.org/package/wai-middleware-auth>
 license:             MIT


### PR DESCRIPTION
GHC 9.0 requires generated typeclass instances to be generated before they are used.