### PR TITLE
Add support for reverse_proxy using https

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.2.6.0
+
+- Add support for https in reverse_proxy
+
 # 0.2.5.1
 
 - Add support for GHC 9.0.

--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ To use a reverse proxy instead of a file server, replace `file_server` with
 reverse_proxy:
   host: myapp.example.com
   port: 80
+  secure: false
 ```
 
 ### Self-hosted GitLab

--- a/src/Network/Wai/Auth/Config.hs
+++ b/src/Network/Wai/Auth/Config.hs
@@ -42,8 +42,9 @@ data FileServer = FileServer
 
 -- | Configuration for reverse proxy application.
 data ReverseProxy = ReverseProxy
-    { rpHost :: T.Text -- ^ Hostname of the webserver
-    , rpPort :: Int -- ^ Port of the webserver
+    { rpHost   :: T.Text -- ^ Hostname of the destination webserver
+    , rpPort   :: Int -- ^ Port of the destination webserver
+    , rpSecure :: Maybe Bool -- ^ Should the request be sent to destination webbserver using https or not (default: false)
     }
 
 -- | Available services.

--- a/wai-middleware-auth.cabal
+++ b/wai-middleware-auth.cabal
@@ -1,6 +1,6 @@
 cabal-version:       1.18
 name:                wai-middleware-auth
-version:             0.2.5.1
+version:             0.2.6.0
 synopsis:            Authentication middleware that secures WAI application
 description:         Please see the README and Haddocks at <https://www.stackage.org/package/wai-middleware-auth>
 license:             MIT


### PR DESCRIPTION
This PR resolves #29 by introducing the optional boolean configuration parameter `secure`:

```yaml
reverse_proxy:
  host: myapp.example.com
  port: 443
  secure: true
```
